### PR TITLE
SYS-1535: Add CLICC events link to navbar

### DIFF
--- a/charts/prod-signage-values.yaml
+++ b/charts/prod-signage-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/digital-signage-hours
-  tag: v1.0.0
+  tag: v1.0.1
   pullPolicy: Always
 
 nameOverride: ""

--- a/signs/templates/signs/base.html
+++ b/signs/templates/signs/base.html
@@ -16,6 +16,7 @@
 <body>
     <ul class="navbar">
         <li><a href="/get_hours_url/">Generate Hours URL</a></li>
+        <li><a href="/display_clicc_events/">CLICC Events Display</a></li>
         <li><a href="/admin/">Admin (Configure Locations)</a></li>
         <li><a href="/logs/">Logs</a></li>
         <li><a href="/release_notes/">Release Notes</a></li>

--- a/signs/templates/signs/release_notes.html
+++ b/signs/templates/signs/release_notes.html
@@ -3,5 +3,16 @@
 {% block content %}
 <h3>Release Notes</h3>
 <hr/>
-<h4>Nothing yet!</h4>
+<h4>1.0.1</h4>
+<p><i>February 22, 2024</i></p>
+<ul>
+    <li>Add link to CLICC events display.</li>
+</ul>
+<h4>1.0.0</h4>
+<p><i>February 21, 2024</i></p>
+<ul>
+    <li>Display library hours and CLICC classroom events for digital signage.</li>
+    <li>Support generation of URLs for the digital signage system.</li>
+    <li>Allow configuration of locations.</li>
+</ul>
 {% endblock %}


### PR DESCRIPTION
Implements [SYS-1535](https://uclalibrary.atlassian.net/browse/SYS-1535)

Adds a direct link to the CLICC events display as the 2nd item in the navbar. 

[SYS-1535]: https://uclalibrary.atlassian.net/browse/SYS-1535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ