### PR TITLE
SYS-1537: Truncate long event titles with ellipses

### DIFF
--- a/static/css/events.css
+++ b/static/css/events.css
@@ -108,6 +108,10 @@ hr {
 
 .event p {
   margin: 10px auto;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .msg {


### PR DESCRIPTION
Implements SYS-1537

This is a quick fix to the display of events with titles that would span more than two lines in the calendar. Two events today demonstrate this:

<img width="443" alt="image" src="https://github.com/UCLALibrary/digital-signage-hours/assets/7283991/f9f61ffc-6504-42bc-8ac3-0909b98735ec">


Limitations of this approach:

* This code relies on an unofficial CSS property (`-webkit-line-clamp`) that is currently available in [all browsers other than IE](https://caniuse.com/?search=webkit-line-clamp). I'm having trouble confirming what exactly Rise Vision is using to render web pages, but I suspect it's Chrome after looking at some of their public GitHub repos. [This one](https://github.com/Rise-Vision/widget-settings-ui-core) says "At this time Chrome is the only browser that this project and Rise Vision supports.", but I'm not sure whether that refers to the web interface used to set up displays, or to the player itself.
* This truncation is applied to all event titles that span more than two lines, even if the event is longer. I think this looks reasonable since it's consistent, but we could consider allowing longer titles on events lasting more than an hour.
