### PR TITLE
SYS-1539: Allow public views to be embedded in iframes

### DIFF
--- a/signs/views.py
+++ b/signs/views.py
@@ -2,6 +2,7 @@ import logging
 from django.shortcuts import render
 from django.http import HttpRequest, HttpResponse
 from django.contrib.auth.decorators import login_required
+from django.views.decorators.clickjacking import xframe_options_exempt
 from django.conf import settings
 from signs.models import Location
 from signs.views_utils import (
@@ -40,6 +41,8 @@ def get_hours_url(request: HttpRequest) -> HttpResponse:
     )
 
 
+# This view is public, and needs to be allowed in a Rise Vision iframe.
+@xframe_options_exempt
 def display_hours(
     request: HttpRequest, location_id: int, orientation: str
 ) -> HttpResponse:
@@ -74,6 +77,8 @@ def display_hours(
     return render(request, "signs/display.html", context)
 
 
+# This view is public, and needs to be allowed in a Rise Vision iframe.
+@xframe_options_exempt
 def display_clicc_events(request: HttpRequest) -> HttpResponse:
     """Display events for CLICC classroom locations.
     This view is used by the digital signage system."""


### PR DESCRIPTION
Implements [SYS-1539](https://uclalibrary.atlassian.net/browse/SYS-1539).

This PR uses a Django decorator to disable built-in "click-jacking" protection for the 2 public views which are used by our signs.  These need to be able to embed URLs in local iframes to display the content.

The `django.views.decorators.clickjacking.xframe_options_exempt` decorator removes the default `X-Frame-Options: DENY` header, allowing the response to be embedded in an iframe in any domain.  This is necessary since we don't know, or control, the hosted Rise Vision sign domain(s).

This solution is simpler than trying to set up a custom Content Security Policy (CSP) via `django-csp`, which still would have required wildcards in `frame-ancestors`.

Testing: Awkward... I tested by running Apache locally in another container and verifying that (a) without the decorator, the view could not be embedded, and (b) with the decorator, the embedded view displays.

```
mkdir /tmp/foobar
cd /tmp/foobar
# create html file with this content
cat foo.html
<html>
        <head><title>My HTML Test</title></head>
        <body>
                <p>HTML goes here</p>
                <iframe width="1080" height="1920" src="http://127.0.0.1:8000/display_hours/4690/landscape" title="Arts Library Hours"></iframe>
        </body>
</html>

# run apache in docker, mounting current directory and exposing port 80
docker run --rm -d --name apache -p 80:80 -v $(pwd):/usr/local/apache2/htdocs/ httpd:2.4

# visit http://127.0](http://127.0.0.1/foo.html
```

With the decorator:
![iframe_allowed](https://github.com/UCLALibrary/digital-signage-hours/assets/2213836/783251d8-9a2b-4974-a5ce-e5f4a7fa7134)

Without the decorator:
![iframe_not_allowed pn](https://github.com/UCLALibrary/digital-signage-hours/assets/2213836/255b7f2e-666f-4fed-be7e-aadcdb2d5c3d)


[SYS-1539]: https://uclalibrary.atlassian.net/browse/SYS-1539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ