### PR TITLE
SYS-1538: fix incorrect URL scheme in production

### DIFF
--- a/charts/prod-signage-values.yaml
+++ b/charts/prod-signage-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/digital-signage-hours
-  tag: v1.0.2
+  tag: v1.0.3
   pullPolicy: Always
 
 nameOverride: ""

--- a/project/settings.py
+++ b/project/settings.py
@@ -16,6 +16,7 @@ from pathlib import Path
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+RUN_ENV = os.getenv("DJANGO_RUN_ENV")
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/

--- a/signs/templates/signs/release_notes.html
+++ b/signs/templates/signs/release_notes.html
@@ -3,11 +3,27 @@
 {% block content %}
 <h3>Release Notes</h3>
 <hr/>
+
+<h4>1.0.3</h4>
+<p><i>February 23, 2024</i></p>
+<ul>
+    <li>Allow displays to be embedded on external pages.</li>
+    <li>Fix bug with URL schemes in generated links.</li>
+    <li>Truncate long event titles with ellipses.</li>
+</ul>
+
+<h4>1.0.2</h4>
+<p><i>February 22, 2024</i></p>
+<ul>
+    <li>Fix bug with LibCal Events widget variable.</li>
+</ul>
+
 <h4>1.0.1</h4>
 <p><i>February 22, 2024</i></p>
 <ul>
     <li>Add link to CLICC events display.</li>
 </ul>
+
 <h4>1.0.0</h4>
 <p><i>February 21, 2024</i></p>
 <ul>

--- a/signs/tests.py
+++ b/signs/tests.py
@@ -28,12 +28,28 @@ class ConstructDisplayURLTestCase(TestCase):
     def setUp(self):
         Location.objects.create(name="Powell Library", location_id=1)
 
-    def test_construct_display_url(self):
+    def test_construct_display_url_prod(self):
         powell = Location.objects.get(location_id=1)
         response = self.client.get("get_hours_url/")
         request = response.wsgi_request
-        url = construct_display_url(request, powell.location_id, "portrait_small")
-        # dummy request will have host of "testserver" and scheme of "http"
+        run_env = "prod"
+        url = construct_display_url(
+            request, powell.location_id, "portrait_small", run_env
+        )
+        # dummy request will have host of "testserver",
+        # run_env = "prod" means scheme should be "https"
+        self.assertEqual(url, "https://testserver/display_hours/1/portrait_small")
+
+    def test_construct_display_url_dev(self):
+        powell = Location.objects.get(location_id=1)
+        response = self.client.get("get_hours_url/")
+        request = response.wsgi_request
+        run_env = "dev"
+        url = construct_display_url(
+            request, powell.location_id, "portrait_small", run_env
+        )
+        # dummy request will have host of "testserver",
+        # run_env != "prod" means scheme should be "http"
         self.assertEqual(url, "http://testserver/display_hours/1/portrait_small")
 
 

--- a/signs/views.py
+++ b/signs/views.py
@@ -31,7 +31,9 @@ def get_hours_url(request: HttpRequest) -> HttpResponse:
         if location_form.is_valid():
             location_id = location_form.cleaned_data["location"].location_id
             orientation = location_form.cleaned_data["orientation"]
-            url = construct_display_url(request, location_id, orientation)
+            # run_env is used to determine the correct scheme for the URL (http or https)
+            run_env = settings.RUN_ENV
+            url = construct_display_url(request, location_id, orientation, run_env)
 
     context = {"location_form": location_form, "url": url}
     return render(

--- a/signs/views_utils.py
+++ b/signs/views_utils.py
@@ -115,12 +115,19 @@ def format_date(date: str) -> str:
 
 
 def construct_display_url(
-    request: HttpRequest, location_id: int, orientation: str
+    request: HttpRequest, location_id: int, orientation: str, run_env: str
 ) -> str:
     """Construct URL for display of hours given location ID and orientation."""
 
-    scheme = request.scheme
     host = request.get_host()
+
+    # request.scheme can incorrectly return "http" when the site is running on HTTPS,
+    # so we use the run_env variable to determine the correct scheme
+    if run_env == "prod":
+        scheme = "https"
+    else:
+        scheme = "http"
+
     return f"{scheme}://{host}/display_hours/{location_id}/{orientation}"
 
 

--- a/signs/views_utils.py
+++ b/signs/views_utils.py
@@ -123,10 +123,10 @@ def construct_display_url(
 
     # request.scheme can incorrectly return "http" when the site is running on HTTPS,
     # so we use the run_env variable to determine the correct scheme
-    if run_env == "prod":
-        scheme = "https"
-    else:
+    if run_env == "dev":
         scheme = "http"
+    else:
+        scheme = "https"
 
     return f"{scheme}://{host}/display_hours/{location_id}/{orientation}"
 


### PR DESCRIPTION
Implements [SYS-1538](https://uclalibrary.atlassian.net/browse/SYS-1538)

Includes these changes:

* Adds `RUN_ENV` variable to `settings.py` (already present in `prod-signage-values.yaml` and `configmap.yaml`, so no Chart changes needed).
* Passes this variable from the view to the `construct_display_url()` function in `views_utils.py` for conditional scheme selection.
* Updates existing test to match these changes, and adds an additional test to cover both dev and prod environments.
* Adds release notes for 1.0.2 and 1.0.3.
* Bumps tag version to 1.0.3 for deploy.

[SYS-1538]: https://uclalibrary.atlassian.net/browse/SYS-1538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ