### PR TITLE
SYS-1540: Add link to application from admin page

### DIFF
--- a/charts/prod-signage-values.yaml
+++ b/charts/prod-signage-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/digital-signage-hours
-  tag: v1.0.3
+  tag: v1.0.4
   pullPolicy: Always
 
 nameOverride: ""

--- a/signs/templates/signs/release_notes.html
+++ b/signs/templates/signs/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.4</h4>
+<p><i>February 23, 2024</i></p>
+<ul>
+    <li>Add link from admin page to main site.</li>
+</ul>
+
 <h4>1.0.3</h4>
 <p><i>February 23, 2024</i></p>
 <ul>

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -1,0 +1,14 @@
+{% extends "admin/base.html" %}
+
+{% load static %}
+{% block extrahead %}
+    <link rel="icon" type="image/x-icon" href="{% static 'favicon.ico' %}"/>
+{% endblock %}
+
+{% block title %}Digital Signage Admin{% endblock %}
+
+{% block branding %}
+<h1><a href="{% url 'admin:index' %}">Digital Signage Administration</a></h1>
+{% endblock %}
+
+{% block nav-global %}<a href="{{ site_url }}">Digital Signage Home</a>{% endblock %}


### PR DESCRIPTION
Implements [SYS-1540](https://uclalibrary.atlassian.net/browse/SYS-1540)

Adds a new link (in addition to existing "VIEW SITE") from the Admin interface navbar to the app home page. Also changes some generic Django wording on admin pages, and includes release notes and tag bump for deployment.

[SYS-1540]: https://uclalibrary.atlassian.net/browse/SYS-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ