### PR TITLE
SYS-1553: Create 1920x1080 landscape sign display

### DIFF
--- a/charts/prod-signage-values.yaml
+++ b/charts/prod-signage-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/digital-signage-hours
-  tag: v1.0.4
+  tag: v1.0.5
   pullPolicy: Always
 
 nameOverride: ""

--- a/signs/forms.py
+++ b/signs/forms.py
@@ -3,7 +3,8 @@ from signs.models import Location
 
 
 ORIENTATION_CHOICES = [
-    ("landscape", "Landscape (3840x2160)"),
+    ("landscape_small", "Landscape (1920x1080)"),
+    ("landscape_large", "Landscape (3840x2160)"),
     ("portrait_small", "Portrait (1080x1920)"),
     ("portrait_large", "Portrait (2160x3840)"),
 ]

--- a/signs/templates/signs/display.html
+++ b/signs/templates/signs/display.html
@@ -30,10 +30,13 @@
                         <span class="day">{{ day.weekday }}</span>
                         <span class="time">{{ day.rendered_hours }}</span>
                     </li>
-                    {% if forloop.counter == 4 and stylesheet == "css/landscape.css" %}
+                    {# no parentheses in Django tabs, so use nested ifs for clarity #}
+                    {% if forloop.counter == 4 %}
+                        {% if stylesheet == "css/landscape_large.css" or stylesheet == "css/landscape_small.css"%}
             </ul>
             <hr>
             <ul>
+                        {% endif %}
                     {% endif %}
                 {% endfor %}
             </ul>

--- a/signs/templates/signs/display.html
+++ b/signs/templates/signs/display.html
@@ -30,7 +30,7 @@
                         <span class="day">{{ day.weekday }}</span>
                         <span class="time">{{ day.rendered_hours }}</span>
                     </li>
-                    {# no parentheses in Django tabs, so use nested ifs for clarity #}
+                    {# no parentheses in Django template tags, so use nested ifs for clarity #}
                     {% if forloop.counter == 4 %}
                         {% if stylesheet == "css/landscape_large.css" or stylesheet == "css/landscape_small.css"%}
             </ul>

--- a/signs/templates/signs/release_notes.html
+++ b/signs/templates/signs/release_notes.html
@@ -3,6 +3,11 @@
 {% block content %}
 <h3>Release Notes</h3>
 <hr/>
+<h4>1.0.5</h4>
+<p><i>March 5, 2024</i></p>
+<ul>
+    <li>Add 1920x1080 version of landscape sign.</li>
+</ul>
 
 <h4>1.0.4</h4>
 <p><i>February 23, 2024</i></p>

--- a/signs/templates/signs/release_notes.html
+++ b/signs/templates/signs/release_notes.html
@@ -7,6 +7,7 @@
 <p><i>March 5, 2024</i></p>
 <ul>
     <li>Add 1920x1080 version of landscape sign.</li>
+    <li>Change landscape sign styling to better fit screen size.</li>
 </ul>
 
 <h4>1.0.4</h4>

--- a/static/css/landscape_large.css
+++ b/static/css/landscape_large.css
@@ -1,0 +1,81 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-family: "Karbon", Arial, Helvetica, sans-serif;
+  font-size: 60px;
+  color: #ffffff;
+  width: 3840px;
+  height: 2160px;
+  background-repeat: no-repeat;
+  background-image: url("/static/img/landscape_background.png");
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  padding: 50px 100px;
+}
+
+h1 {
+  margin: 1;
+  padding: 0 0 0 100px;
+  color: #ffd100;
+  font-size: 2.2rem;
+  font-weight: 600;
+}
+
+h2 {
+  padding: 0;
+  margin: 40px 0 60px 0.3rem;
+  font-size: 1.8rem;
+}
+
+ul {
+  width: 43%;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+li {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 0.3rem;
+  font-size: 1.4rem;
+}
+
+.time {
+  margin-left: auto;
+}
+
+svg {
+  height: 4rem;
+}
+
+header {
+  display: flex;
+  align-items: center;
+}
+
+.columns {
+  width: 80%;
+  display: flex;
+  justify-content: space-between;
+}
+
+hr {
+  height: auto;
+  width: 2.5px;
+  margin: 0;
+  background-color: #ffffff;
+}
+
+.today {
+  background-color: #2774ae;
+  box-shadow: 0 0 5px 5px #8bb8e8;
+  color: #ffd100;
+}

--- a/static/css/landscape_small.css
+++ b/static/css/landscape_small.css
@@ -6,11 +6,12 @@
 
 html {
   font-family: "Karbon", Arial, Helvetica, sans-serif;
-  font-size: 35px;
+  font-size: 30px;
   color: #ffffff;
-  width: 3840px;
-  height: 2160px;
+  width: 1920px;
+  height: 1080px;
   background-repeat: no-repeat;
+  background-size: cover;
   background-image: url("/static/img/landscape_background.png");
 }
 
@@ -62,7 +63,7 @@ header {
 }
 
 .columns {
-  width: 45%;
+  width: 80%;
   display: flex;
   justify-content: space-between;
 }


### PR DESCRIPTION
Implements [SYS-1553](https://uclalibrary.atlassian.net/browse/SYS-1553)

Adds a "small landscape" display option for hours signage. This is added to the dropdown in the homepage view via `forms.py`. Landscape CSS is split into `landscape_large` and `landscape_small` files with different values, which are selected by the display view based on the URL. Release notes and tag bump for deployment are also included.


[SYS-1553]: https://uclalibrary.atlassian.net/browse/SYS-1553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ