### PR TITLE
SYS-1754: Update Django to 4.2.19 to patch security issues

### DIFF
--- a/charts/prod-signage-values.yaml
+++ b/charts/prod-signage-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/digital-signage-hours
-  tag: v1.0.9
+  tag: v1.0.10
   pullPolicy: Always
 
 nameOverride: ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==4.2.16
+Django==4.2.19
 psycopg2==2.9.7
 whitenoise==6.5.0
 gunicorn==23.0.0

--- a/signs/templates/signs/release_notes.html
+++ b/signs/templates/signs/release_notes.html
@@ -3,6 +3,12 @@
 {% block content %}
 <h3>Release Notes</h3>
 <hr/>
+<h4>1.0.10</h4>
+<p><i>February 28, 2025</i></p>
+<ul>
+    <li>Updated Django to 4.2.19 to patch security issues.</li>
+</ul>
+
 <h4>1.0.9</h4>
 <p><i>November 20, 2024</i></p>
 <ul>


### PR DESCRIPTION
Implements [SYS-1754](https://uclalibrary.atlassian.net/browse/SYS-1754)

- Updated Django to 4.2.19
- Bumped Helm chart version tag
- Added release note

**Testing**
✅ All tests passed in dev environment

[SYS-1754]: https://uclalibrary.atlassian.net/browse/SYS-1754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ