### PR TITLE
SYS-1832: fix logout link

### DIFF
--- a/charts/prod-signage-values.yaml
+++ b/charts/prod-signage-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/digital-signage-hours
-  tag: v1.0.11
+  tag: v1.0.12
   pullPolicy: Always
 
 nameOverride: ""

--- a/signs/templates/signs/base.html
+++ b/signs/templates/signs/base.html
@@ -20,7 +20,10 @@
         <li><a href="/admin/">Admin (Configure Locations)</a></li>
         <li><a href="/logs/">Logs</a></li>
         <li><a href="/release_notes/">Release Notes</a></li>
-        <li><a href="/accounts/logout/">Logout</a></li>
+        <li><form action="{% url 'logout' %}" method="post">
+            {% csrf_token %}
+            {% bootstrap_button "Logout" button_type="submit" button_class="link-primary" %}
+        </form></li>
     </ul>
     <br>
     <div class="container">

--- a/signs/templates/signs/release_notes.html
+++ b/signs/templates/signs/release_notes.html
@@ -3,6 +3,12 @@
 {% block content %}
 <h3>Release Notes</h3>
 <hr/>
+<h4>1.0.12</h4>
+<p><i>May 16, 2025</i></p>
+<ul>
+    <li>Fixed bug with logout link in navigation bar.</li>
+</ul>
+
 <h4>1.0.11</h4>
 <p><i>May 15, 2025</i></p>
 <ul>

--- a/static/css/base_style.css
+++ b/static/css/base_style.css
@@ -13,9 +13,17 @@ ul.navbar {
   border-right: 1px solid #bcbcc5;
 }
 
-.navbar li a {
+.navbar li a,
+.navbar li button {
   display: block;
   text-align: center;
-  padding: 10px 12px;
   text-decoration: none;
+}
+
+.navbar li a {
+  padding: 10px 12px;
+}
+
+.navbar li form {
+  height: 24px;
 }


### PR DESCRIPTION
Implements [SYS-1832](https://uclalibrary.atlassian.net/browse/SYS-1832)

As with [SYS-1829](https://uclalibrary.atlassian.net/browse/SYS-1829), we can't logout with GET requests as of Django 5.2, so the navbar link is replaced with a form to send a POST request. CSS is updated to make the new button match existing links, and release notes and tag bump for deployment are included.

### Testing
As changes are only in templates and CSS, no restart is needed. Log into the [Application](http://127.0.0.1:8000/) make sure you can log out from both the app and admin sides.

[SYS-1832]: https://uclalibrary.atlassian.net/browse/SYS-1832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYS-1829]: https://uclalibrary.atlassian.net/browse/SYS-1829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ